### PR TITLE
Weekly Repeat Bug Fix

### DIFF
--- a/assets/components/mxcalendars/js/mgr/widgets/mxcalendars.grid.js
+++ b/assets/components/mxcalendars/js/mgr/widgets/mxcalendars.grid.js
@@ -493,6 +493,7 @@ mxcCore.window.CreateCal = function(config) {
                                 var rt = Ext.getCmp('crepeattype');
                                 if(rt.getValue() === 1){
                                     Ext.getCmp('crepeaton').show();
+									Ext.getCmp('crepeaton').doLayout();
                                 } else { Ext.getCmp('crepeaton').hide(); }
                                 }}
                             }


### PR DESCRIPTION
When choosing to repeat an even weekly on a new event the days of week
would all be rendered with "width: 0px". This is fixed by forcing the
layout AFTER the container is shown.
