### PR TITLE
Fix #95: Added option for starting weeks from Monday

### DIFF
--- a/core/components/mxcalendars/model/mxcalendars/mxcalendars.class.php
+++ b/core/components/mxcalendars/model/mxcalendars/mxcalendars.class.php
@@ -444,10 +444,12 @@ class mxCalendars {
             $chunkMonth = $this->loadChunk($tpls->month);
             
             $heading = '';
+	        $startDOW = $this->modx->getOption('mxcalendars.start_monday') ? 1 : 0;
             for($i=0;$i<7;$i++){
-                    if($this->debug) echo '&nbsp;&nbsp;'.strftime('%A', strtotime('+ '.$i.' day', $startMonthCalDate)).'<br />';
-                    $thisDOW = trim('mxcalendars.label_dow_'.strtolower(strftime('%u', strtotime('+ '.$i.' day', $startMonthCalDate))));
-                    $heading.=$this->getChunk($tpls->heading, array('dayOfWeekId'=>'','dayOfWeekClass'=>'mxcdow', 'dayOfWeek'=> $this->modx->lexicon($thisDOW) ));
+	                $numberDOW = $startDOW + $i;
+                    if($this->debug) echo '&nbsp;&nbsp;'.strftime('%A', strtotime("+ {$numberDOW} day", $startMonthCalDate)).'<br />';
+                    $thisDOW = trim('mxcalendars.label_dow_'.strtolower(strftime('%u', strtotime("+ {$numberDOW} day", $startMonthCalDate))));
+                    $heading.=$this->getChunk($tpls->heading, array('dayOfWeekId'=>$numberDOW,'dayOfWeekClass'=>'mxcdow', 'dayOfWeek'=> $this->modx->lexicon($thisDOW) ));
             }
             //-- Set additional day placeholders for week
             $phHeading = array(
@@ -467,9 +469,10 @@ class mxCalendars {
                 if($this->debug) echo '---------------<br />';
                 // Week Start date
                 $iWeek = strtotime('+ '.$var.' week', $startMonthCalDate);
-                $diw = 0;
+	            $i = 0;
                 $days = '';
                 do{
+	                $diw = $startDOW + $i;
                     // Get the week's days
                     $iDay = strtotime('+ '.$diw.' day', $iWeek);
                     $thisMonth = strftime('%m', $iDay);
@@ -560,7 +563,7 @@ class mxCalendars {
                         );
                     //$days.=$chunkDay->process($phDay);
                     $days.=$this->getChunk($tpls->day, $phDay);
-                } while (++$diw < 7);
+                } while (++$i < 7);
                 
                 if($this->debug) echo '<br />';
                 //-- Set additional day placeholders for week


### PR DESCRIPTION
In order to use just set `mxcalendars.start_monday` option to `TRUE` from config UI.